### PR TITLE
Add poem revision system (data capture layer)

### DIFF
--- a/cfml/app/client/member/poem/composer/composer.cfm
+++ b/cfml/app/client/member/poem/composer/composer.cfm
@@ -10,6 +10,7 @@
 	// ------------------------------------------------------------------------------- //
 
 	switch ( router.next( "editor" ) ) {
+		case "createRevision":
 		case "editor":
 		case "rhymes":
 		case "saveInBackground":

--- a/cfml/app/client/member/poem/composer/createRevision.cfm
+++ b/cfml/app/client/member/poem/composer/createRevision.cfm
@@ -1,0 +1,36 @@
+<cfscript>
+
+	// Define properties for dependency-injection.
+	poemRevisionService = request.ioc.get( "core.lib.service.poem.PoemRevisionService" );
+	requestHelper = request.ioc.get( "core.lib.web.RequestHelper" );
+
+	// ColdFusion language extensions (global functions).
+	include "/core/cfmlx.cfm";
+
+	// ------------------------------------------------------------------------------- //
+	// ------------------------------------------------------------------------------- //
+
+	param name="url.poemID" type="numeric";
+
+	request.response.template = "blank";
+
+	if ( request.isPost ) {
+
+		try {
+
+			poemRevisionService.createRevision(
+				authContext = request.authContext,
+				poemID = val( url.poemID )
+			);
+
+		} catch ( any error ) {
+
+			requestHelper.processError( error );
+
+		}
+
+	}
+
+	include "./createRevision.view.cfm";
+
+</cfscript>

--- a/cfml/app/client/member/poem/composer/createRevision.view.cfm
+++ b/cfml/app/client/member/poem/composer/createRevision.view.cfm
@@ -1,0 +1,7 @@
+<cfsavecontent variable="request.response.body">
+<cfoutput>
+
+	<!--- No visible output needed. --->
+
+</cfoutput>
+</cfsavecontent>

--- a/cfml/app/client/member/poem/composer/editor.view.cfm
+++ b/cfml/app/client/member/poem/composer/editor.view.cfm
@@ -97,6 +97,16 @@
 			xClass="speechTools"
 		/>
 
+		<div
+			x-data="z6s31p.RevisionTracker( '#router.urlForParts( 'member.poem.composer.createRevision', 'poemID', poem.id )#' )"
+			@input.window="
+				if ( $event.target.id === 'form--content' ) {
+					handleContentInput();
+				}
+			"
+			style="display: none;">
+		</div>
+
 	</article>
 
 	<div z6s31p class="wordTools">

--- a/cfml/app/client/member/poem/composer/editor.view.js
+++ b/cfml/app/client/member/poem/composer/editor.view.js
@@ -1,0 +1,144 @@
+window.z6s31p = {
+	RevisionTracker,
+};
+
+function RevisionTracker( revisionUrl ) {
+
+	var IDLE_DELAY = ( 30 * 1000 );
+	var CAP_DELAY = ( 10 * 60 * 1000 );
+
+	var idleTimer = null;
+	var capTimer = null;
+	var isRequestInFlight = false;
+
+	return {
+		// Life-Cycle Methods.
+		destroy,
+
+		// Public Methods.
+		handleContentInput,
+	};
+
+	// ---
+	// LIFE-CYCLE METHODS.
+	// ---
+
+	/**
+	* I teardown the component.
+	*/
+	function destroy() {
+
+		clearTimeout( idleTimer );
+		clearTimeout( capTimer );
+
+	}
+
+	// ---
+	// PUBLIC METHODS.
+	// ---
+
+	/**
+	* I handle input events from the content textarea.
+	*/
+	function handleContentInput() {
+
+		resetIdleTimer();
+		ensureCapTimer();
+
+	}
+
+	// ---
+	// PRIVATE METHODS.
+	// ---
+
+	/**
+	* I create a revision by posting to the server endpoint.
+	*/
+	function createRevision() {
+
+		if ( isRequestInFlight ) {
+
+			return;
+
+		}
+
+		clearTimeout( idleTimer );
+		clearTimeout( capTimer );
+		idleTimer = null;
+		capTimer = null;
+
+		var xsrfToken = getCookieValue( "XSRF-TOKEN" );
+
+		if ( ! xsrfToken ) {
+
+			return;
+
+		}
+
+		isRequestInFlight = true;
+
+		var body = new FormData();
+		body.append( "X-XSRF-TOKEN", xsrfToken );
+
+		fetch(
+			revisionUrl,
+			{
+				method: "POST",
+				body: body,
+			}
+		)
+			.catch(
+				function() {
+					// Silently ignore network errors for revision creation.
+				}
+			)
+			.finally(
+				function() {
+					isRequestInFlight = false;
+				}
+			)
+		;
+
+	}
+
+
+	/**
+	* I start the cap timer if it isn't already running.
+	*/
+	function ensureCapTimer() {
+
+		if ( capTimer === null ) {
+
+			capTimer = setTimeout( createRevision, CAP_DELAY );
+
+		}
+
+	}
+
+
+	/**
+	* I get the value of the cookie with the given name.
+	*/
+	function getCookieValue( name ) {
+
+		var match = document.cookie.match( new RegExp( "(^|;\\s*)" + name + "=([^;]*)" ) );
+
+		return match
+			? decodeURIComponent( match[ 2 ] )
+			: ""
+		;
+
+	}
+
+
+	/**
+	* I reset the idle timer, restarting the countdown.
+	*/
+	function resetIdleTimer() {
+
+		clearTimeout( idleTimer );
+		idleTimer = setTimeout( createRevision, IDLE_DELAY );
+
+	}
+
+}

--- a/cfml/app/core/lib/model/poem/revision/PoemRevisionGateway.cfc
+++ b/cfml/app/core/lib/model/poem/revision/PoemRevisionGateway.cfc
@@ -1,0 +1,146 @@
+<cfcomponent extends="core.lib.model.BaseGateway">
+
+	<cffunction name="init" returnType="void">
+
+		<cfset super.init(
+			indexPrefixes = [
+				"id",
+				"poemID",
+			]
+		) />
+
+	</cffunction>
+
+	<!--- PUBLIC METHODS. --->
+
+	<cffunction name="create" returnType="numeric">
+
+		<cfargument name="poemID" type="numeric" required="true" />
+		<cfargument name="revisionNumber" type="numeric" required="true" />
+		<cfargument name="content" type="string" required="true" />
+		<cfargument name="createdAt" type="date" required="true" />
+
+		<cfquery name="local.results" result="local.metaResults">
+			INSERT INTO
+				poem_revision
+			SET
+				poemID = <cfqueryparam value="#poemID#" cfsqltype="cf_sql_bigint" />,
+				revisionNumber = <cfqueryparam value="#revisionNumber#" cfsqltype="cf_sql_integer" />,
+				content = <cfqueryparam value="#content#" cfsqltype="cf_sql_varchar" />,
+				createdAt = <cfqueryparam value="#createdAt#" cfsqltype="cf_sql_timestamp" />
+		</cfquery>
+
+		<cfreturn val( metaResults.generatedKey ) />
+
+	</cffunction>
+
+
+	<cffunction name="deleteByFilter" returnType="void">
+
+		<cfargument name="id" type="numeric" required="false" />
+		<cfargument name="poemID" type="numeric" required="false" />
+
+		<cfset assertIndexPrefix( arguments ) />
+
+		<cfquery name="local.results" result="local.metaResults">
+			DELETE FROM
+				poem_revision
+			WHERE
+				TRUE
+
+			<cfif ! isNull( id )>
+				AND
+					id = <cfqueryparam value="#id#" cfsqltype="cf_sql_bigint" />
+			</cfif>
+
+			<cfif ! isNull( poemID )>
+				AND
+					poemID = <cfqueryparam value="#poemID#" cfsqltype="cf_sql_bigint" />
+			</cfif>
+		</cfquery>
+
+	</cffunction>
+
+
+	<cffunction name="getByFilter" returnType="array">
+
+		<cfargument name="id" type="numeric" required="false" />
+		<cfargument name="poemID" type="numeric" required="false" />
+
+		<cfset assertIndexPrefix( arguments ) />
+
+		<cfquery name="local.results" result="local.metaResults" returnType="array">
+			SELECT
+				id,
+				poemID,
+				revisionNumber,
+				content,
+				createdAt
+			FROM
+				poem_revision
+			WHERE
+				TRUE
+
+			<cfif ! isNull( id )>
+				AND
+					id = <cfqueryparam value="#id#" cfsqltype="cf_sql_bigint" />
+			</cfif>
+
+			<cfif ! isNull( poemID )>
+				AND
+					poemID = <cfqueryparam value="#poemID#" cfsqltype="cf_sql_bigint" />
+			</cfif>
+
+			ORDER BY
+				revisionNumber ASC
+		</cfquery>
+
+		<cfreturn results />
+
+	</cffunction>
+
+
+	<cffunction name="getLatestByPoemID" returnType="array">
+
+		<cfargument name="poemID" type="numeric" required="true" />
+
+		<cfquery name="local.results" result="local.metaResults" returnType="array">
+			SELECT
+				id,
+				poemID,
+				revisionNumber,
+				content,
+				createdAt
+			FROM
+				poem_revision
+			WHERE
+				poemID = <cfqueryparam value="#poemID#" cfsqltype="cf_sql_bigint" />
+			ORDER BY
+				revisionNumber DESC
+			LIMIT
+				1
+		</cfquery>
+
+		<cfreturn results />
+
+	</cffunction>
+
+
+	<cffunction name="getNextRevisionNumber" returnType="numeric">
+
+		<cfargument name="poemID" type="numeric" required="true" />
+
+		<cfquery name="local.results" result="local.metaResults" returnType="array">
+			SELECT
+				( COALESCE( MAX( revisionNumber ), 0 ) + 1 ) AS nextRevisionNumber
+			FROM
+				poem_revision
+			WHERE
+				poemID = <cfqueryparam value="#poemID#" cfsqltype="cf_sql_bigint" />
+		</cfquery>
+
+		<cfreturn val( results[ 1 ].nextRevisionNumber ) />
+
+	</cffunction>
+
+</cfcomponent>

--- a/cfml/app/core/lib/model/poem/revision/PoemRevisionModel.cfc
+++ b/cfml/app/core/lib/model/poem/revision/PoemRevisionModel.cfc
@@ -1,0 +1,84 @@
+component {
+
+	// Define properties for dependency-injection.
+	property name="gateway" ioc:type="core.lib.model.poem.revision.PoemRevisionGateway";
+	property name="validation" ioc:type="core.lib.model.poem.revision.PoemRevisionValidation";
+
+	// ColdFusion language extensions (global functions).
+	include "/core/cfmlx.cfm";
+
+	// ---
+	// PUBLIC METHODS.
+	// ---
+
+	/**
+	* I create a new model.
+	*/
+	public numeric function create(
+		required numeric poemID,
+		required numeric revisionNumber,
+		required string content,
+		required date createdAt
+		) {
+
+		content = validation.contentFrom( content );
+
+		return gateway.create(
+			poemID = poemID,
+			revisionNumber = revisionNumber,
+			content = content,
+			createdAt = createdAt
+		);
+
+	}
+
+
+	/**
+	* I delete the models that match the given filters.
+	*/
+	public void function deleteByFilter(
+		numeric id,
+		numeric poemID
+		) {
+
+		gateway.deleteByFilter( argumentCollection = arguments );
+
+	}
+
+
+	/**
+	* I get the models that match the given filters.
+	*/
+	public array function getByFilter(
+		numeric id,
+		numeric poemID
+		) {
+
+		return gateway.getByFilter( argumentCollection = arguments );
+
+	}
+
+
+	/**
+	* I get the latest revision for the given poem. Returns an empty struct if no
+	* revisions exist.
+	*/
+	public struct function getLatestByPoemID( required numeric poemID ) {
+
+		var results = gateway.getLatestByPoemID( poemID );
+
+		return maybeArrayFirst( results );
+
+	}
+
+
+	/**
+	* I get the next revision number for the given poem.
+	*/
+	public numeric function getNextRevisionNumber( required numeric poemID ) {
+
+		return gateway.getNextRevisionNumber( poemID );
+
+	}
+
+}

--- a/cfml/app/core/lib/model/poem/revision/PoemRevisionValidation.cfc
+++ b/cfml/app/core/lib/model/poem/revision/PoemRevisionValidation.cfc
@@ -1,0 +1,50 @@
+component
+	extends = "core.lib.model.BaseValidation"
+	{
+
+	// ColdFusion language extensions (global functions).
+	include "/core/cfmlx.cfm";
+
+	// ---
+	// VALIDATION METHODS.
+	// ---
+
+	/**
+	* I validate and return the normalized value.
+	*/
+	public string function contentFrom( required string input ) {
+
+		return pipeline(
+			normalizeString( input ),
+			[
+				assertMaxLength: [ 3000, "App.Model.Poem.Revision.Content.TooLong" ],
+				assertUniformEncoding: [ "App.Model.Poem.Revision.Content.SuspiciousEncoding" ]
+			]
+		);
+
+	}
+
+	// ---
+	// ERROR METHODS.
+	// ---
+
+	/**
+	* I throw a model error.
+	*/
+	public void function throwForbiddenError() {
+
+		throw( type = "App.Model.Poem.Revision.Forbidden" );
+
+	}
+
+
+	/**
+	* I throw a model error.
+	*/
+	public void function throwNotFoundError() {
+
+		throw( type = "App.Model.Poem.Revision.NotFound" );
+
+	}
+
+}

--- a/cfml/app/core/lib/service/poem/PoemCascade.cfc
+++ b/cfml/app/core/lib/service/poem/PoemCascade.cfc
@@ -2,6 +2,7 @@ component {
 
 	// Define properties for dependency-injection.
 	property name="poemModel" ioc:type="core.lib.model.poem.PoemModel";
+	property name="poemRevisionModel" ioc:type="core.lib.model.poem.revision.PoemRevisionModel";
 	property name="shareCascade" ioc:type="core.lib.service.poem.share.ShareCascade";
 	property name="shareModel" ioc:type="core.lib.model.poem.share.ShareModel";
 
@@ -20,6 +21,7 @@ component {
 		required struct poem
 		) {
 
+		deleteRevisions( user, poem );
 		deleteShares( user, poem );
 
 		poemModel.deleteByFilter( id = poem.id );
@@ -29,6 +31,19 @@ component {
 	// ---
 	// PRIVATE METHODS.
 	// ---
+
+	/**
+	* I delete the revisions associated with the given poem.
+	*/
+	private void function deleteRevisions(
+		required struct user,
+		required struct poem
+		) {
+
+		poemRevisionModel.deleteByFilter( poemID = poem.id );
+
+	}
+
 
 	/**
 	* I delete the shares associated with the given poem.

--- a/cfml/app/core/lib/service/poem/PoemRevisionService.cfc
+++ b/cfml/app/core/lib/service/poem/PoemRevisionService.cfc
@@ -1,0 +1,68 @@
+component {
+
+	// Define properties for dependency-injection.
+	property name="poemAccess" ioc:type="core.lib.service.poem.PoemAccess";
+	property name="poemRevisionModel" ioc:type="core.lib.model.poem.revision.PoemRevisionModel";
+
+	// ColdFusion language extensions (global functions).
+	include "/core/cfmlx.cfm";
+
+	// ---
+	// PUBLIC METHODS.
+	// ---
+
+	/**
+	* I create an initial revision for a newly created poem.
+	*/
+	public numeric function createInitialRevision(
+		required numeric poemID,
+		required string content,
+		required date createdAt
+		) {
+
+		return poemRevisionModel.create(
+			poemID = poemID,
+			revisionNumber = 1,
+			content = content,
+			createdAt = createdAt
+		);
+
+	}
+
+
+	/**
+	* I create a revision for the given poem if the content has changed since the last
+	* revision.
+	*/
+	public void function createRevision(
+		required struct authContext,
+		required numeric poemID
+		) {
+
+		var context = poemAccess.getContext( authContext, poemID, "canUpdate" );
+		var poem = context.poem;
+
+		var latestRevision = poemRevisionModel.getLatestByPoemID( poemID );
+
+		// No-op guard: skip if content hasn't changed since the last revision.
+		if (
+			! latestRevision.isEmpty() &&
+			! compare( poem.content, latestRevision.content )
+			) {
+
+			return;
+
+		}
+
+		var nextRevisionNumber = poemRevisionModel.getNextRevisionNumber( poemID );
+
+		poemRevisionModel.create(
+			poemID = poemID,
+			revisionNumber = nextRevisionNumber,
+			content = poem.content,
+			createdAt = utcNow()
+		);
+
+	}
+
+}

--- a/cfml/app/core/lib/service/poem/PoemService.cfc
+++ b/cfml/app/core/lib/service/poem/PoemService.cfc
@@ -6,6 +6,7 @@ component {
 	property name="poemAccess" ioc:type="core.lib.service.poem.PoemAccess";
 	property name="poemCascade" ioc:type="core.lib.service.poem.PoemCascade";
 	property name="poemModel" ioc:type="core.lib.model.poem.PoemModel";
+	property name="poemRevisionService" ioc:type="core.lib.service.poem.PoemRevisionService";
 	property name="poemValidation" ioc:type="core.lib.model.poem.PoemValidation";
 	property name="userModel" ioc:type="core.lib.model.user.UserModel";
 
@@ -32,12 +33,20 @@ component {
 
 		testCollectionID( authContext, userID, collectionID );
 
+		var createdAt = utcNow();
+
 		var poemID = poemModel.create(
 			userID = user.id,
 			collectionID = collectionID,
 			name = name,
 			content = content,
-			createdAt = utcNow()
+			createdAt = createdAt
+		);
+
+		poemRevisionService.createInitialRevision(
+			poemID = poemID,
+			content = content,
+			createdAt = createdAt
 		);
 
 		return poemID;

--- a/cfml/app/core/lib/web/ErrorTranslator.cfc
+++ b/cfml/app/core/lib/web/ErrorTranslator.cfc
@@ -94,6 +94,15 @@ component hint = "I help translate application errors into appropriate response 
 			case "App.Model.Poem.NotFound":
 				return asModelNotFound( error, "poem" );
 			break;
+			case "App.Model.Poem.Revision.Content.SuspiciousEncoding":
+				return asModelStringSuspiciousEncoding( error, "poem revision" );
+			break;
+			case "App.Model.Poem.Revision.Content.TooLong":
+				return asModelStringTooLong( error, "poem revision", metadata );
+			break;
+			case "App.Model.Poem.Revision.NotFound":
+				return asModelNotFound( error, "poem revision" );
+			break;
 			case "App.Model.Poem.Share.Name.SuspiciousEncoding":
 				return asModelStringSuspiciousEncoding( error, "share name" );
 			break;

--- a/cfml/app/db/2026-02-11-001-poem-revision.sql
+++ b/cfml/app/db/2026-02-11-001-poem-revision.sql
@@ -1,0 +1,13 @@
+
+CREATE TABLE `poem_revision` (
+	`id` bigint unsigned NOT NULL AUTO_INCREMENT,
+	`poemID` bigint unsigned NOT NULL,
+	`revisionNumber` int unsigned NOT NULL,
+	`content` varchar(3000) NOT NULL,
+	`createdAt` datetime NOT NULL,
+	PRIMARY KEY (`id`),
+	UNIQUE KEY `byPoemRevision` (`poemID`, `revisionNumber`),
+	CONSTRAINT `fk_poem_revision_poem`
+		FOREIGN KEY (`poemID`) REFERENCES `poem` (`id`)
+		ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;


### PR DESCRIPTION
## Summary
- Add `poem_revision` table and Model/Gateway/Validation triple for storing poem content snapshots
- Create a PoemRevisionService with no-op guard (skips if content unchanged since last revision)
- Add client-side JavaScript windowing in the composer: 30s idle timer + 10min continuous editing cap triggers a revision snapshot via `fetch()` POST
- Auto-create revision #1 when a poem is first created, and cascade-delete revisions when a poem is deleted
- Add error translations for revision validation errors

## Test plan
- [ ] Run the SQL migration (`cfml/app/db/2026-02-11-001-poem-revision.sql`)
- [ ] Rebuild client assets (`docker compose up client`)
- [ ] Reinitialize the app (`?init=1`)
- [ ] Create a new poem — verify a revision #1 row exists in `poem_revision`
- [ ] Open the composer, type in the textarea, wait 30+ seconds — verify a new revision row is created
- [ ] Type continuously for 10+ minutes — verify the cap timer creates a revision
- [ ] Edit without changing content (type then undo) — verify no duplicate revision (no-op guard)
- [ ] Delete a poem — verify its revisions are also deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)