### PR TITLE
Add withSort preset to gateway/model getByFilter methods.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -383,6 +383,8 @@ public void function deleteRevision( required struct revision ) {
 
 **Order by `id` instead of date columns**: Auto-increment IDs are inserted chronologically. Prefer `ORDER BY id DESC` over date columns to leverage existing indexes.
 
+**`withSort` preset for `getByFilter`**: Gateways that return multi-row result sets accept a `withSort` argument with domain-level preset names (e.g., `"name"`, `"newest"`). The gateway maps presets to SQL `ORDER BY` clauses via `cfswitch`, keeping sort logic in the data-access layer instead of re-sorting arrays in controllers. The default is `"id"` (or the table's natural key). Skip `withSort` for gateways that only ever return a single row (e.g., AccountGateway, TimezoneGateway, PresenceGateway).
+
 ## Error and Flash Message Translations
 
 When adding `throw()` statements or flash messages, corresponding translations must be added:

--- a/cfml/app/client/member/collection/list/list.cfm
+++ b/cfml/app/client/member/collection/list/list.cfm
@@ -26,10 +26,10 @@
 	*/
 	private struct function getPartial( required struct authContext ) {
 
-		var collections = CollectionModel
-			.getByFilter( userID = authContext.user.id )
-			.sort( ( a, b ) => compareNoCase( a.name, b.name ) )
-		;
+		var collections = CollectionModel.getByFilter(
+			userID = authContext.user.id,
+			withSort = "name"
+		);
 
 		return {
 			collections

--- a/cfml/app/client/member/collection/view/view.cfm
+++ b/cfml/app/client/member/collection/view/view.cfm
@@ -42,10 +42,10 @@
 		var context = collectionAccess.getContext( authContext, collectionID, "canView" );
 		var collection = context.collection;
 
-		var poems = poemModel
-			.getByFilter( collectionID = collection.id )
-			.sort( ( a, b ) => compareNoCase( a.name, b.name ) )
-		;
+		var poems = poemModel.getByFilter(
+			collectionID = collection.id,
+			withSort = "name"
+		);
 
 		return {
 			collection,

--- a/cfml/app/client/member/poem/add/add.cfm
+++ b/cfml/app/client/member/poem/add/add.cfm
@@ -89,10 +89,10 @@
 	*/
 	private struct function getPartial( required struct authContext ) {
 
-		var collections = collectionModel
-			.getByFilter( userID = authContext.user.id )
-			.sort( ( a, b ) => compareNoCase( a.name, b.name ) )
-		;
+		var collections = collectionModel.getByFilter(
+			userID = authContext.user.id,
+			withSort = "name"
+		);
 
 		return {
 			collections,

--- a/cfml/app/client/member/poem/edit/edit.cfm
+++ b/cfml/app/client/member/poem/edit/edit.cfm
@@ -93,10 +93,10 @@
 		var context = poemAccess.getContext( authContext, poemID, "canUpdate" );
 		var poem = context.poem;
 
-		var collections = collectionModel
-			.getByFilter( userID = authContext.user.id )
-			.sort( ( a, b ) => compareNoCase( a.name, b.name ) )
-		;
+		var collections = collectionModel.getByFilter(
+			userID = authContext.user.id,
+			withSort = "name"
+		);
 
 		return {
 			poem,

--- a/cfml/app/client/member/poem/revision/list/list.cfm
+++ b/cfml/app/client/member/poem/revision/list/list.cfm
@@ -41,10 +41,10 @@
 
 		var context = revisionAccess.getContextForParent( authContext, poemID, "canViewAny" );
 		var poem = context.poem;
-		var revisions = revisionModel
-			.getByFilter( poemID = poem.id )
-			.sort( ( a, b ) => sgn( b.id - a.id ) )
-		;
+		var revisions = revisionModel.getByFilter(
+			poemID = poem.id,
+			withSort = "newest"
+		);
 
 		return {
 			poem,

--- a/cfml/app/client/member/poem/share/view/view.cfm
+++ b/cfml/app/client/member/poem/share/view/view.cfm
@@ -46,13 +46,11 @@
 		var share = context.share;
 		var poem = context.poem;
 
-		var viewings = viewingModel
-			.getByFilter(
-				poemID = poem.id,
-				shareID = share.id
-			)
-			.sort( ( a, b ) => sgn( b.id - a.id ) )
-		;
+		var viewings = viewingModel.getByFilter(
+			poemID = poem.id,
+			shareID = share.id,
+			withSort = "newest"
+		);
 
 		return {
 			poem,

--- a/cfml/app/core/lib/model/collection/CollectionGateway.cfc
+++ b/cfml/app/core/lib/model/collection/CollectionGateway.cfc
@@ -70,6 +70,7 @@
 
 		<cfargument name="id" type="numeric" required="false" />
 		<cfargument name="userID" type="numeric" required="false" />
+		<cfargument name="withSort" type="string" required="false" default="id" />
 
 		<cfset assertIndexPrefix( arguments ) />
 
@@ -98,7 +99,15 @@
 			</cfif>
 
 			ORDER BY
-				id ASC
+				<cfswitch expression="#withSort#">
+					<cfcase value="name">
+						name ASC,
+						id ASC
+					</cfcase>
+					<cfdefaultcase>
+						id ASC
+					</cfdefaultcase>
+				</cfswitch>
 		</cfquery>
 
 		<cfreturn results />

--- a/cfml/app/core/lib/model/collection/CollectionModel.cfc
+++ b/cfml/app/core/lib/model/collection/CollectionModel.cfc
@@ -74,7 +74,8 @@ component {
 	*/
 	public array function getByFilter(
 		numeric id,
-		numeric userID
+		numeric userID,
+		string withSort
 		) {
 
 		return gateway.getByFilter( argumentCollection = arguments );

--- a/cfml/app/core/lib/model/language/WordGateway.cfc
+++ b/cfml/app/core/lib/model/language/WordGateway.cfc
@@ -62,6 +62,7 @@
 	<cffunction name="getByFilter" returnType="array">
 
 		<cfargument name="token" type="string" required="false" />
+		<cfargument name="withSort" type="string" required="false" default="token" />
 
 		<cfset assertIndexPrefix( arguments ) />
 
@@ -85,7 +86,11 @@
 			</cfif>
 
 			ORDER BY
-				token ASC
+				<cfswitch expression="#withSort#">
+					<cfdefaultcase>
+						token ASC
+					</cfdefaultcase>
+				</cfswitch>
 		</cfquery>
 
 		<cfreturn results />

--- a/cfml/app/core/lib/model/language/WordModel.cfc
+++ b/cfml/app/core/lib/model/language/WordModel.cfc
@@ -70,7 +70,10 @@ component {
 	/**
 	* I get the model that match the given filters.
 	*/
-	public array function getByFilter( string token ) {
+	public array function getByFilter(
+		string token,
+		string withSort
+		) {
 
 		return gateway.getByFilter( argumentCollection = arguments );
 

--- a/cfml/app/core/lib/model/oneTimeToken/OneTimeTokenGateway.cfc
+++ b/cfml/app/core/lib/model/oneTimeToken/OneTimeTokenGateway.cfc
@@ -60,6 +60,7 @@
 
 		<cfargument name="id" type="numeric" required="false" />
 		<cfargument name="expiresAtBefore" type="date" required="false" />
+		<cfargument name="withSort" type="string" required="false" default="id" />
 
 		<cfset assertIndexPrefix( arguments ) />
 
@@ -86,7 +87,11 @@
 			</cfif>
 
 			ORDER BY
-				id ASC
+				<cfswitch expression="#withSort#">
+					<cfdefaultcase>
+						id ASC
+					</cfdefaultcase>
+				</cfswitch>
 		</cfquery>
 
 		<cfreturn results />

--- a/cfml/app/core/lib/model/oneTimeToken/OneTimeTokenModel.cfc
+++ b/cfml/app/core/lib/model/oneTimeToken/OneTimeTokenModel.cfc
@@ -48,7 +48,8 @@ component {
 	*/
 	public array function getByFilter(
 		numeric id,
-		date expiresAtBefore
+		date expiresAtBefore,
+		string withSort
 		) {
 
 		return gateway.getByFilter( argumentCollection = arguments );

--- a/cfml/app/core/lib/model/poem/PoemGateway.cfc
+++ b/cfml/app/core/lib/model/poem/PoemGateway.cfc
@@ -73,6 +73,7 @@
 		<cfargument name="id" type="numeric" required="false" />
 		<cfargument name="userID" type="numeric" required="false" />
 		<cfargument name="collectionID" type="numeric" required="false" />
+		<cfargument name="withSort" type="string" required="false" default="id" />
 
 		<cfset assertIndexPrefix( arguments ) />
 
@@ -106,7 +107,15 @@
 			</cfif>
 
 			ORDER BY
-				id ASC
+				<cfswitch expression="#withSort#">
+					<cfcase value="name">
+						name ASC,
+						id ASC
+					</cfcase>
+					<cfdefaultcase>
+						id ASC
+					</cfdefaultcase>
+				</cfswitch>
 		</cfquery>
 
 		<cfreturn results />

--- a/cfml/app/core/lib/model/poem/PoemModel.cfc
+++ b/cfml/app/core/lib/model/poem/PoemModel.cfc
@@ -75,7 +75,8 @@ component {
 	public array function getByFilter(
 		numeric id,
 		numeric userID,
-		numeric collectionID
+		numeric collectionID,
+		string withSort
 		) {
 
 		return gateway.getByFilter( argumentCollection = arguments );

--- a/cfml/app/core/lib/model/poem/RevisionGateway.cfc
+++ b/cfml/app/core/lib/model/poem/RevisionGateway.cfc
@@ -68,6 +68,7 @@
 
 		<cfargument name="id" type="numeric" required="false" />
 		<cfargument name="poemID" type="numeric" required="false" />
+		<cfargument name="withSort" type="string" required="false" default="id" />
 
 		<cfset assertIndexPrefix( arguments ) />
 
@@ -95,7 +96,14 @@
 			</cfif>
 
 			ORDER BY
-				updatedAt DESC
+				<cfswitch expression="#withSort#">
+					<cfcase value="newest">
+						id DESC
+					</cfcase>
+					<cfdefaultcase>
+						id ASC
+					</cfdefaultcase>
+				</cfswitch>
 		</cfquery>
 
 		<cfreturn results />

--- a/cfml/app/core/lib/model/poem/RevisionModel.cfc
+++ b/cfml/app/core/lib/model/poem/RevisionModel.cfc
@@ -71,7 +71,8 @@ component {
 	*/
 	public array function getByFilter(
 		numeric id,
-		numeric poemID
+		numeric poemID,
+		string withSort
 		) {
 
 		return gateway.getByFilter( argumentCollection = arguments );

--- a/cfml/app/core/lib/model/poem/share/ShareGateway.cfc
+++ b/cfml/app/core/lib/model/poem/share/ShareGateway.cfc
@@ -83,6 +83,7 @@
 		<cfargument name="id" type="numeric" required="false" />
 		<cfargument name="poemID" type="numeric" required="false" />
 		<cfargument name="token" type="string" required="false" />
+		<cfargument name="withSort" type="string" required="false" default="id" />
 
 		<cfset assertIndexPrefix( arguments ) />
 
@@ -122,7 +123,11 @@
 			</cfif>
 
 			ORDER BY
-				id ASC
+				<cfswitch expression="#withSort#">
+					<cfdefaultcase>
+						id ASC
+					</cfdefaultcase>
+				</cfswitch>
 		</cfquery>
 
 		<cfreturn results />

--- a/cfml/app/core/lib/model/poem/share/ShareModel.cfc
+++ b/cfml/app/core/lib/model/poem/share/ShareModel.cfc
@@ -91,7 +91,8 @@ component {
 	public array function getByFilter(
 		numeric id,
 		numeric poemID,
-		string token
+		string token,
+		string withSort
 		) {
 
 		return gateway.getByFilter( argumentCollection = arguments );

--- a/cfml/app/core/lib/model/poem/share/ViewingGateway.cfc
+++ b/cfml/app/core/lib/model/poem/share/ViewingGateway.cfc
@@ -122,6 +122,7 @@
 		<cfargument name="poemID" type="numeric" required="false" />
 		<cfargument name="shareID" type="numeric" required="false" />
 		<cfargument name="ipAddress" type="string" required="false" />
+		<cfargument name="withSort" type="string" required="false" default="id" />
 
 		<cfset assertIndexPrefix( arguments ) />
 
@@ -161,7 +162,14 @@
 			</cfif>
 
 			ORDER BY
-				id ASC
+				<cfswitch expression="#withSort#">
+					<cfcase value="newest">
+						id DESC
+					</cfcase>
+					<cfdefaultcase>
+						id ASC
+					</cfdefaultcase>
+				</cfswitch>
 		</cfquery>
 
 		<cfreturn results />

--- a/cfml/app/core/lib/model/poem/share/ViewingModel.cfc
+++ b/cfml/app/core/lib/model/poem/share/ViewingModel.cfc
@@ -81,7 +81,8 @@ component {
 		numeric id,
 		numeric poemID,
 		numeric shareID,
-		string ipAddress
+		string ipAddress,
+		string withSort
 		) {
 
 		return gateway.getByFilter( argumentCollection = arguments );

--- a/cfml/app/core/lib/model/session/SessionGateway.cfc
+++ b/cfml/app/core/lib/model/session/SessionGateway.cfc
@@ -78,6 +78,7 @@
 		<cfargument name="id" type="numeric" required="false" />
 		<cfargument name="userID" type="numeric" required="false" />
 		<cfargument name="token" type="string" required="false" />
+		<cfargument name="withSort" type="string" required="false" default="id" />
 
 		<cfset assertIndexPrefix( arguments ) />
 
@@ -113,7 +114,11 @@
 			</cfif>
 
 			ORDER BY
-				id ASC
+				<cfswitch expression="#withSort#">
+					<cfdefaultcase>
+						id ASC
+					</cfdefaultcase>
+				</cfswitch>
 		</cfquery>
 
 		<cfreturn decodeColumns( results ) />

--- a/cfml/app/core/lib/model/session/SessionModel.cfc
+++ b/cfml/app/core/lib/model/session/SessionModel.cfc
@@ -85,7 +85,8 @@ component {
 	public array function getByFilter(
 		numeric id,
 		string token,
-		numeric userID
+		numeric userID,
+		string withSort
 		) {
 
 		return gateway.getByFilter( argumentCollection = arguments );

--- a/cfml/app/core/lib/model/system/task/TaskGateway.cfc
+++ b/cfml/app/core/lib/model/system/task/TaskGateway.cfc
@@ -18,6 +18,7 @@
 
 		<cfargument name="id" type="string" required="false" />
 		<cfargument name="overdueAt" type="date" required="false" />
+		<cfargument name="withSort" type="string" required="false" default="id" />
 
 		<cfquery name="local.results" result="local.metaResults" returnType="array">
 			SELECT
@@ -45,7 +46,11 @@
 			</cfif>
 
 			ORDER BY
-				id ASC
+				<cfswitch expression="#withSort#">
+					<cfdefaultcase>
+						id ASC
+					</cfdefaultcase>
+				</cfswitch>
 		</cfquery>
 
 		<cfreturn decodeColumns( results ) />

--- a/cfml/app/core/lib/model/system/task/TaskModel.cfc
+++ b/cfml/app/core/lib/model/system/task/TaskModel.cfc
@@ -34,7 +34,8 @@ component {
 	*/
 	public array function getByFilter(
 		string id,
-		date overdueAt
+		date overdueAt,
+		string withSort
 		) {
 
 		return gateway.getByFilter( argumentCollection = arguments );

--- a/cfml/app/core/lib/model/user/UserGateway.cfc
+++ b/cfml/app/core/lib/model/user/UserGateway.cfc
@@ -66,6 +66,7 @@
 
 		<cfargument name="id" type="numeric" required="false" />
 		<cfargument name="email" type="string" required="false" />
+		<cfargument name="withSort" type="string" required="false" default="id" />
 
 		<cfset assertIndexPrefix( arguments ) />
 
@@ -91,7 +92,11 @@
 			</cfif>
 
 			ORDER BY
-				id ASC
+				<cfswitch expression="#withSort#">
+					<cfdefaultcase>
+						id ASC
+					</cfdefaultcase>
+				</cfswitch>
 		</cfquery>
 
 		<cfreturn results />

--- a/cfml/app/core/lib/model/user/UserModel.cfc
+++ b/cfml/app/core/lib/model/user/UserModel.cfc
@@ -66,7 +66,8 @@ component {
 	*/
 	public array function getByFilter(
 		numeric id,
-		string email
+		string email,
+		string withSort
 		) {
 
 		return gateway.getByFilter( argumentCollection = arguments );

--- a/cfml/app/core/lib/service/poem/RevisionNavigator.cfc
+++ b/cfml/app/core/lib/service/poem/RevisionNavigator.cfc
@@ -16,10 +16,10 @@ component {
 	*/
 	public struct function getPosition( required struct revision ) {
 
-		var siblings = revisionModel
-			.getByFilter( poemID = revision.poemID )
-			.sort( ( a, b ) => sgn( b.id - a.id ) )
-		;
+		var siblings = revisionModel.getByFilter(
+			poemID = revision.poemID,
+			withSort = "newest"
+		);
 
 		var i = siblings.find( ( element ) => ( element.id == revision.id ) );
 		// The siblings are sorted newest-first. As such, the revision number is the


### PR DESCRIPTION
Move result-set sorting from ColdFusion .sort() calls in controllers down into SQL ORDER BY clauses via a new withSort argument on getByFilter. Each gateway maps domain-level preset names (e.g., "name", "newest") to ORDER BY columns through a cfswitch block. Controllers now pass withSort instead of re-sorting arrays after the fact.

Presets added: "name" (CollectionGateway, PoemGateway), "newest" (RevisionGateway, ViewingGateway). All other gateways get the cfswitch scaffold with a default-only case for future extensibility. Single-row gateways (AccountGateway, TimezoneGateway, PresenceGateway) are excluded since sorting is meaningless there. RevisionGateway default normalized from updatedAt DESC to id ASC to match the project convention.