### PR TITLE
Add nicer local dev log viewer experience.

### DIFF
--- a/cfml/app/client/_shared/less/ui.less
+++ b/cfml/app/client/_shared/less/ui.less
@@ -1329,6 +1329,30 @@ pre code {
 }
 
 // ---
+// CFDUMP STYLES.
+// 
+// These are here for development purposes only, to make the output of the CFDump / dump()
+// easier to read. For some reason, that output is hella tiny.
+// ---
+
+html body table[class^='cfdump_'] {
+	border-collapse: separate ;
+	border-spacing: 2px ;
+	font-family: var( --font-family-control ) ;
+	margin-bottom: 0 ;
+
+	&:not(:last-child) {
+		margin-bottom: var( --space-block ) ;
+	}
+
+	th,
+	td {
+		font-size: 1rem ;
+		padding: 0.4em 0.55em ;
+	}
+}
+
+// ---
 // UTILITY CLASSES.
 //
 // Note: these are here as a last resort. I think I might use these during the exploratory

--- a/cfml/app/client/_shared/tag/localDevelopment.cfm
+++ b/cfml/app/client/_shared/tag/localDevelopment.cfm
@@ -3,6 +3,7 @@
 	// Define properties for dependency-injection.
 	config = request.ioc.get( "config" );
 	requestMetadata = request.ioc.get( "core.lib.web.RequestMetadata" );
+	ui = request.ioc.get( "core.lib.web.UI" );
 
 	// ColdFusion language extensions (global functions).
 	include "/core/cfmlx.cfm";

--- a/cfml/app/client/_shared/tag/localDevelopment.view.cfm
+++ b/cfml/app/client/_shared/tag/localDevelopment.view.cfm
@@ -14,9 +14,11 @@
 			</a>
 
 			<cfif logCount>
-				<strong style="color: red ;">
-					#numberFormat( logCount )# Logs
-				</strong>
+				<a #ui.attrHref( "dev.log" )# target="_blank" style="color: red ;">
+					<strong>
+						#numberFormat( logCount )# Logs
+					</strong>
+				</a>
 			</cfif>
 		</div>
 

--- a/cfml/app/client/dev/dev.cfm
+++ b/cfml/app/client/dev/dev.cfm
@@ -2,6 +2,7 @@
 
 	// Define properties for dependency-injection.
 	config = request.ioc.get( "config" );
+	requestHelper = request.ioc.get( "core.lib.web.RequestHelper" );
 	router = request.ioc.get( "core.lib.web.Router" );
 
 	// ColdFusion language extensions (global functions).
@@ -17,6 +18,8 @@
 
 	}
 
+	requestHelper.ensureXsrfToken();
+
 	// ------------------------------------------------------------------------------- //
 	// ------------------------------------------------------------------------------- //
 
@@ -24,6 +27,7 @@
 
 	switch ( router.next() ) {
 		case "keys":
+		case "log":
 		case "test":
 			cfmodule( template = router.nextTemplate() );
 		break;

--- a/cfml/app/client/dev/log/log.cfm
+++ b/cfml/app/client/dev/log/log.cfm
@@ -1,0 +1,61 @@
+<cfscript>
+
+	// Define properties for dependency-injection.
+	devLogs = request.ioc.get( "core.lib.util.DevLogs" );
+	requestHelper = request.ioc.get( "core.lib.web.RequestHelper" );
+	router = request.ioc.get( "core.lib.web.Router" );
+	ui = request.ioc.get( "core.lib.web.UI" );
+
+	// ColdFusion language extensions (global functions).
+	include "/core/cfmlx.cfm";
+
+	// ------------------------------------------------------------------------------- //
+	// ------------------------------------------------------------------------------- //
+
+	param name="form.deleteLogs" type="string" default="";
+
+	partial = getPartial();
+	entries = partial.entries;
+
+	title = "Local Development Logs";
+	errorResponse = "";
+
+	request.response.title = title;
+
+	if ( request.isPost && ( form.deleteLogs == "true" ) ) {
+
+		try {
+
+			devLogs.deleteAll();
+
+			router.goto([
+				event: "dev.log"
+			]);
+
+		} catch ( any error ) {
+
+			errorResponse = requestHelper.processError( error );
+
+		}
+
+	}
+
+	include "./log.view.cfm";
+
+	// ------------------------------------------------------------------------------- //
+	// ------------------------------------------------------------------------------- //
+
+	/**
+	* I get the partial data for the view.
+	*/
+	private struct function getPartial() {
+
+		var entries = devLogs.getAll();
+
+		return {
+			entries,
+		};
+
+	}
+
+</cfscript>

--- a/cfml/app/client/dev/log/log.view.cfm
+++ b/cfml/app/client/dev/log/log.view.cfm
@@ -1,0 +1,53 @@
+<cfsavecontent variable="request.response.body">
+<cfoutput>
+
+	<div r2m8kt class="r2m8kt">
+
+		<h1>
+			#e( title )#
+		</h1>
+
+		<cfif entries.len()>
+
+			<cfmodule
+				template="/client/_shared/tag/errorMessage.cfm"
+				response="#errorResponse#">
+			</cfmodule>
+
+			<form method="post" action="#request.postBackAction#" x-prevent-double-submit>
+				<cfmodule template="/client/_shared/tag/xsrf.cfm" />
+
+				<cfloop array="#entries#" item="entry" index="i">
+
+					<details #ui.attrOpen( i == 1 )# r2m8kt class="disclosure">
+						<summary r2m8kt class="summary">
+							#e( entry.summary )#
+						</summary>
+						<section r2m8kt class="content">
+							<cfset dump( entry.data ) />
+						</section>
+					</details>
+
+				</cfloop>
+
+				<div class="uiFormButtons">
+					<button type="submit" name="deleteLogs" value="true" class="uiButton isDanger">
+						Delete Logs
+					</button>
+				</div>
+			</form>
+
+		</cfif>
+
+		<cfif ! entries.len()>
+
+			<p>
+				No logs &mdash; rock on with your bad self!
+			</p>
+
+		</cfif>
+
+	</div>
+
+</cfoutput>
+</cfsavecontent>

--- a/cfml/app/client/dev/log/log.view.less
+++ b/cfml/app/client/dev/log/log.view.less
@@ -1,0 +1,22 @@
+[r2m8kt] {
+	&.r2m8kt {}
+
+	&.disclosure {
+		background: var( --gray-1 ) ;
+		border: 1px solid var( --rule-content ) ;
+		border-radius: var( --radius ) ;
+		margin-bottom: var( --space-block ) ;
+	}
+
+	&.summary {
+		cursor: pointer ;
+		font-weight: var( --font-weight ) ;
+		padding: var( --pad-block ) var( --pad-inline ) ;
+	}
+
+	&.content {
+		background: var( --fill ) ;
+		overflow-x: auto ;
+		padding: var( --pad-block ) var( --pad-inline ) ;
+	}
+}

--- a/cfml/app/core/cfmlx.cfm
+++ b/cfml/app/core/cfmlx.cfm
@@ -316,14 +316,6 @@
 			abort = abort
 		);
 
-		// If we're outputting to the browser (the default behavior), inject custom styles
-		// for better readability for my aging eyes.
-		if ( output == "browser" ) {
-
-			dumpStyles();
-
-		}
-
 	}
 
 
@@ -336,51 +328,6 @@
 		) {
 
 		dump( argumentCollection = arguments );
-
-	}
-
-
-	/**
-	* I inject style tags that make the CFDump output easier to read.
-	*/
-	private void function dumpStyles() {
-
-		// For better debugging on how these styles are being injected, we're going to
-		// include the call-stack in the style tag content (as a comment).
-		var stacktrace = callStackGet()
-			.map( ( frame ) => "- #frame.template#:#frame.lineNumber#" )
-			.toList( chr( 10 ) & repeatString( chr( 9 ), 4 ) & "* " )
-		;
-
-		// CAUTION: Normally, the use of cfhtmlhead() is considered an ANTI-PATTERN due to
-		// its total lack of accountability. But, in this case, we're fighting fire with
-		// fire. Meaning, the writeDump() tag is already injecting styles magically; and
-		// now, we're also injecting styles magically to counteract their magical styles.
-		cfhtmlhead( text = "
-			<style type='text/css' data-source='Added by the dumpStyles().'>
-				/**
-				* ColdFusion Stacktrace:
-				* #stacktrace#
-				**/
-
-				html body table[class^='cfdump_'] {
-					border-collapse: separate ;
-					border-spacing: 2px ;
-					font-family: verdana, arial, helvetica, sans-serif ;
-					margin-bottom: 1.5rem ;
-
-					& table[class^='cfdump_'] {
-						margin-bottom: 0 ;
-					}
-
-					& th,
-					& td {
-						font-size: 1rem ;
-						padding: 0.4em 0.55em ;
-					}
-				}
-			</style>
-		");
 
 	}
 

--- a/cfml/app/core/lib/util/DevLogs.cfc
+++ b/cfml/app/core/lib/util/DevLogs.cfc
@@ -1,0 +1,173 @@
+/**
+* CAUTION: The payloads consumed in this service are tightly coupled to the Logger
+* service. Which means that when they payloads change shape, the logic here may need to be
+* updated or it will (may) break. I am OK with this tight / fragile coupling because this
+* is a development-only feature and does NOT have to have production-ready robustness.
+*/
+component hint = "I provide access to file-based logs in the development environment." {
+
+	// ColdFusion language extensions (global functions).
+	include "/core/cfmlx.cfm";
+
+	// ---
+	// PUBLIC METHODS.
+	// ---
+
+	/**
+	* I log the given payload to the local log directory.
+	*/
+	public void function create( required struct payload ) {
+
+		var stub = now().dateTimeFormat( "yyyy-mm-dd-HH-nn-ss" );
+		var suffix = lcase( payload.error.type ?: payload.level ?: "unknown" );
+
+		fileWrite(
+			file = expandPath( "/log/#stub#-#suffix#.json" ),
+			data = serializeJson( payload ),
+			charset = "utf-8"
+		);
+
+	}
+
+
+	/**
+	* I delete all the log files from the local log directory.
+	*/
+	public void function deleteAll() {
+
+		for ( var filepath in getFiles() ) {
+
+			fileDelete( filepath );
+
+		}
+
+	}
+
+
+	/**
+	* I get all the log files from the local log directory.
+	*/
+	public array function getAll() {
+
+		return getFiles().map(
+			( filepath ) => {
+
+				var data = simplifyData( deserializeJson( fileRead( filepath, "utf-8" ) ) );
+				var summary = coalesceTruthy(
+					data.error?.message,
+					data.error?.type,
+					data?.message,
+					getFileFromPath( filepath )
+				);
+
+				return {
+					summary,
+					data,
+				};
+
+			}
+		);
+
+	}
+
+	// ---
+	// PRIVATE METHODS.
+	// ---
+
+	/**
+	* I get the list of log filepaths (in date descending order - newest first).
+	*/
+	private array function getFiles() {
+
+		var filepaths = directoryList(
+			path = expandPath( "/log" ),
+			listInfo = "path",
+			filter = "*.json"
+		);
+
+		// The files are written using datetime stamps. Which means that when they are
+		// listed, they come back in date-ascending order. Since this utility is tightly
+		// coupled to DEBUGGING, let's return then in descending order since the developer
+		// will almost certainly want to see the newest logs first.
+		return filepaths.sort( "textnocase", "desc" );
+
+	}
+
+
+	/**
+	* I attempt to simplify the structure of the given data, making it easier for the
+	* developer to read (prioritizing higher importance keys at the top by using an
+	* ordered struct to recreate the data structure).
+	*/
+	private struct function simplifyData( required struct data ) {
+
+		var simplified = [:];
+		var keys = [
+			"error",
+			"level",
+			"type",
+			"message",
+			"detail",
+			"extendedInfo",
+			"tagContext",
+			"data",
+			"context",
+			"url",
+			"form",
+			"cgi",
+		];
+
+		// Prioritize order of selected keys (for visual consumption).
+		for ( var key in keys ) {
+
+			if ( ! data.keyExists( key ) ) {
+
+				continue;
+
+			}
+
+			if ( isStruct( data[ key ] ) ) {
+
+				simplified[ key ] = simplifyData( data[ key ] );
+
+			} else {
+
+				simplified[ key ] = data[ key ];
+
+			}
+
+		}
+
+		// Pick up any left-over keys.
+		for ( var key in data.keyArray() ) {
+
+			// Special skip-cases.
+			switch ( key ) {
+				case "errorcode":
+				case "stacktrace":
+				case "suppressed":
+					continue;
+				break;
+			}
+
+			if ( ! data.keyExists( key ) ) {
+
+				continue;
+
+			}
+
+			if ( simplified.keyExists( key ) ) {
+
+				continue;
+
+			}
+
+			simplified[ key ] = data[ key ];
+
+		}
+
+		return simplified;
+
+	}
+
+}

--- a/cfml/app/core/lib/util/Logger.cfc
+++ b/cfml/app/core/lib/util/Logger.cfc
@@ -3,6 +3,7 @@ component hint = "I provide logging methods for errors and arbitrary data." {
 	// Define properties for dependency-injection.
 	property name="bugSnagLogger" ioc:type="core.lib.integration.bugsnag.BugSnagLogger";
 	property name="config" ioc:type="config";
+	property name="devLogs" ioc:type="core.lib.util.DevLogs";
 	property name="patternsToRedact" ioc:skip;
 	property name="requestMetadata" ioc:type="core.lib.web.RequestMetadata";
 
@@ -105,7 +106,7 @@ component hint = "I provide logging methods for errors and arbitrary data." {
 
 		if ( ! config.isLive ) {
 
-			sendToDevLog([
+			devLogs.create([
 				level: level,
 				message: message,
 				data: data
@@ -145,7 +146,7 @@ component hint = "I provide logging methods for errors and arbitrary data." {
 
 		if ( ! config.isLive ) {
 
-			sendToDevLog([
+			devLogs.create([
 				error: structCopy( error ),
 				message: message,
 				data: data,
@@ -320,23 +321,6 @@ component hint = "I provide logging methods for errors and arbitrary data." {
 				}
 			)
 		;
-
-	}
-
-
-	/**
-	* I log the given payload to the local log directory for developer debugging.
-	*/
-	private void function sendToDevLog( required struct payload ) {
-
-		var stub = now().dateTimeFormat( "yyyy-mm-dd-HH-nn-ss" );
-		var suffix = lcase( payload.error.type ?: payload.level ?: "unknown" );
-
-		fileWrite(
-			file = expandPath( "/log/#stub#-#suffix#.json" ),
-			data = serializeJson( payload ),
-			charset = "utf-8"
-		);
 
 	}
 

--- a/cfml/app/core/lib/web/UI.cfc
+++ b/cfml/app/core/lib/web/UI.cfc
@@ -101,6 +101,22 @@ component {
 
 
 	/**
+	* I return the open attribute based on the given condition.
+	*/
+	public string function attrOpen( required boolean input ) {
+
+		if ( input ) {
+
+			return "open";
+
+		}
+
+		return "";
+
+	}
+
+
+	/**
 	* I return the selected attribute based on the given condition.
 	*/
 	public string function attrSelected( required boolean input ) {


### PR DESCRIPTION
This is still a work in progress; but saving the error logs as `.json` makes them easier to parse and render in the web UI. I tried to prioritize the key-order; but, that's where much of the "WIP"'iness is still to be fine-tuned.

Closes #25