### PR TITLE
Adding `SELECT ... FOR UPDATE` semantics.

### DIFF
--- a/cfml/app/core/lib/model/collection/CollectionGateway.cfc
+++ b/cfml/app/core/lib/model/collection/CollectionGateway.cfc
@@ -71,6 +71,7 @@
 		<cfargument name="id" type="numeric" required="false" />
 		<cfargument name="userID" type="numeric" required="false" />
 		<cfargument name="withSort" type="string" required="false" default="id" />
+		<cfargument name="withLock" type="string" required="false" default="" />
 
 		<cfset assertIndexPrefix( arguments ) />
 
@@ -108,6 +109,15 @@
 						id ASC
 					</cfdefaultcase>
 				</cfswitch>
+
+			<cfswitch expression="#withLock#">
+				<cfcase value="readonly">
+					FOR SHARE
+				</cfcase>
+				<cfcase value="exclusive">
+					FOR UPDATE
+				</cfcase>
+			</cfswitch>
 		</cfquery>
 
 		<cfreturn results />

--- a/cfml/app/core/lib/model/collection/CollectionModel.cfc
+++ b/cfml/app/core/lib/model/collection/CollectionModel.cfc
@@ -54,7 +54,10 @@ component {
 	/**
 	* I get a model.
 	*/
-	public struct function get( required numeric id ) {
+	public struct function get(
+		required numeric id,
+		string withLock
+		) {
 
 		var results = getByFilter( argumentCollection = arguments );
 
@@ -75,7 +78,8 @@ component {
 	public array function getByFilter(
 		numeric id,
 		numeric userID,
-		string withSort
+		string withSort,
+		string withLock
 		) {
 
 		return gateway.getByFilter( argumentCollection = arguments );

--- a/cfml/app/core/lib/model/language/WordGateway.cfc
+++ b/cfml/app/core/lib/model/language/WordGateway.cfc
@@ -63,6 +63,7 @@
 
 		<cfargument name="token" type="string" required="false" />
 		<cfargument name="withSort" type="string" required="false" default="token" />
+		<cfargument name="withLock" type="string" required="false" default="" />
 
 		<cfset assertIndexPrefix( arguments ) />
 
@@ -91,6 +92,15 @@
 						token ASC
 					</cfdefaultcase>
 				</cfswitch>
+
+			<cfswitch expression="#withLock#">
+				<cfcase value="readonly">
+					FOR SHARE
+				</cfcase>
+				<cfcase value="exclusive">
+					FOR UPDATE
+				</cfcase>
+			</cfswitch>
 		</cfquery>
 
 		<cfreturn results />

--- a/cfml/app/core/lib/model/language/WordModel.cfc
+++ b/cfml/app/core/lib/model/language/WordModel.cfc
@@ -52,7 +52,10 @@ component {
 	/**
 	* I get a model.
 	*/
-	public struct function get( required string token ) {
+	public struct function get(
+		required string token,
+		string withLock
+		) {
 
 		var results = getByFilter( argumentCollection = arguments );
 
@@ -72,7 +75,8 @@ component {
 	*/
 	public array function getByFilter(
 		string token,
-		string withSort
+		string withSort,
+		string withLock
 		) {
 
 		return gateway.getByFilter( argumentCollection = arguments );

--- a/cfml/app/core/lib/model/oneTimeToken/OneTimeTokenGateway.cfc
+++ b/cfml/app/core/lib/model/oneTimeToken/OneTimeTokenGateway.cfc
@@ -61,6 +61,7 @@
 		<cfargument name="id" type="numeric" required="false" />
 		<cfargument name="expiresAtBefore" type="date" required="false" />
 		<cfargument name="withSort" type="string" required="false" default="id" />
+		<cfargument name="withLock" type="string" required="false" default="" />
 
 		<cfset assertIndexPrefix( arguments ) />
 
@@ -92,6 +93,15 @@
 						id ASC
 					</cfdefaultcase>
 				</cfswitch>
+
+			<cfswitch expression="#withLock#">
+				<cfcase value="readonly">
+					FOR SHARE
+				</cfcase>
+				<cfcase value="exclusive">
+					FOR UPDATE
+				</cfcase>
+			</cfswitch>
 		</cfquery>
 
 		<cfreturn results />

--- a/cfml/app/core/lib/model/oneTimeToken/OneTimeTokenModel.cfc
+++ b/cfml/app/core/lib/model/oneTimeToken/OneTimeTokenModel.cfc
@@ -49,7 +49,8 @@ component {
 	public array function getByFilter(
 		numeric id,
 		date expiresAtBefore,
-		string withSort
+		string withSort,
+		string withLock
 		) {
 
 		return gateway.getByFilter( argumentCollection = arguments );

--- a/cfml/app/core/lib/model/poem/PoemGateway.cfc
+++ b/cfml/app/core/lib/model/poem/PoemGateway.cfc
@@ -74,6 +74,7 @@
 		<cfargument name="userID" type="numeric" required="false" />
 		<cfargument name="collectionID" type="numeric" required="false" />
 		<cfargument name="withSort" type="string" required="false" default="id" />
+		<cfargument name="withLock" type="string" required="false" default="" />
 
 		<cfset assertIndexPrefix( arguments ) />
 
@@ -116,6 +117,15 @@
 						id ASC
 					</cfdefaultcase>
 				</cfswitch>
+
+			<cfswitch expression="#withLock#">
+				<cfcase value="readonly">
+					FOR SHARE
+				</cfcase>
+				<cfcase value="exclusive">
+					FOR UPDATE
+				</cfcase>
+			</cfswitch>
 		</cfquery>
 
 		<cfreturn results />

--- a/cfml/app/core/lib/model/poem/PoemModel.cfc
+++ b/cfml/app/core/lib/model/poem/PoemModel.cfc
@@ -54,7 +54,10 @@ component {
 	/**
 	* I get a model.
 	*/
-	public struct function get( required numeric id ) {
+	public struct function get(
+		required numeric id,
+		string withLock
+		) {
 
 		var results = getByFilter( argumentCollection = arguments );
 
@@ -76,7 +79,8 @@ component {
 		numeric id,
 		numeric userID,
 		numeric collectionID,
-		string withSort
+		string withSort,
+		string withLock
 		) {
 
 		return gateway.getByFilter( argumentCollection = arguments );

--- a/cfml/app/core/lib/model/poem/RevisionGateway.cfc
+++ b/cfml/app/core/lib/model/poem/RevisionGateway.cfc
@@ -69,6 +69,7 @@
 		<cfargument name="id" type="numeric" required="false" />
 		<cfargument name="poemID" type="numeric" required="false" />
 		<cfargument name="withSort" type="string" required="false" default="id" />
+		<cfargument name="withLock" type="string" required="false" default="" />
 
 		<cfset assertIndexPrefix( arguments ) />
 
@@ -104,6 +105,15 @@
 						id ASC
 					</cfdefaultcase>
 				</cfswitch>
+
+			<cfswitch expression="#withLock#">
+				<cfcase value="readonly">
+					FOR SHARE
+				</cfcase>
+				<cfcase value="exclusive">
+					FOR UPDATE
+				</cfcase>
+			</cfswitch>
 		</cfquery>
 
 		<cfreturn results />

--- a/cfml/app/core/lib/model/poem/RevisionModel.cfc
+++ b/cfml/app/core/lib/model/poem/RevisionModel.cfc
@@ -51,7 +51,10 @@ component {
 	/**
 	* I get a revision by ID.
 	*/
-	public struct function get( required numeric id ) {
+	public struct function get(
+		required numeric id,
+		string withLock
+		) {
 
 		var results = getByFilter( argumentCollection = arguments );
 
@@ -72,7 +75,8 @@ component {
 	public array function getByFilter(
 		numeric id,
 		numeric poemID,
-		string withSort
+		string withSort,
+		string withLock
 		) {
 
 		return gateway.getByFilter( argumentCollection = arguments );

--- a/cfml/app/core/lib/model/poem/share/ShareGateway.cfc
+++ b/cfml/app/core/lib/model/poem/share/ShareGateway.cfc
@@ -84,6 +84,7 @@
 		<cfargument name="poemID" type="numeric" required="false" />
 		<cfargument name="token" type="string" required="false" />
 		<cfargument name="withSort" type="string" required="false" default="id" />
+		<cfargument name="withLock" type="string" required="false" default="" />
 
 		<cfset assertIndexPrefix( arguments ) />
 
@@ -128,6 +129,15 @@
 						id ASC
 					</cfdefaultcase>
 				</cfswitch>
+
+			<cfswitch expression="#withLock#">
+				<cfcase value="readonly">
+					FOR SHARE
+				</cfcase>
+				<cfcase value="exclusive">
+					FOR UPDATE
+				</cfcase>
+			</cfswitch>
 		</cfquery>
 
 		<cfreturn results />

--- a/cfml/app/core/lib/model/poem/share/ShareModel.cfc
+++ b/cfml/app/core/lib/model/poem/share/ShareModel.cfc
@@ -70,7 +70,10 @@ component {
 	/**
 	* I get a model.
 	*/
-	public struct function get( required numeric id ) {
+	public struct function get(
+		required numeric id,
+		string withLock
+		) {
 
 		var results = getByFilter( argumentCollection = arguments );
 
@@ -92,7 +95,8 @@ component {
 		numeric id,
 		numeric poemID,
 		string token,
-		string withSort
+		string withSort,
+		string withLock
 		) {
 
 		return gateway.getByFilter( argumentCollection = arguments );

--- a/cfml/app/core/lib/model/poem/share/ViewingGateway.cfc
+++ b/cfml/app/core/lib/model/poem/share/ViewingGateway.cfc
@@ -123,6 +123,7 @@
 		<cfargument name="shareID" type="numeric" required="false" />
 		<cfargument name="ipAddress" type="string" required="false" />
 		<cfargument name="withSort" type="string" required="false" default="id" />
+		<cfargument name="withLock" type="string" required="false" default="" />
 
 		<cfset assertIndexPrefix( arguments ) />
 
@@ -170,6 +171,15 @@
 						id ASC
 					</cfdefaultcase>
 				</cfswitch>
+
+			<cfswitch expression="#withLock#">
+				<cfcase value="readonly">
+					FOR SHARE
+				</cfcase>
+				<cfcase value="exclusive">
+					FOR UPDATE
+				</cfcase>
+			</cfswitch>
 		</cfquery>
 
 		<cfreturn results />

--- a/cfml/app/core/lib/model/poem/share/ViewingModel.cfc
+++ b/cfml/app/core/lib/model/poem/share/ViewingModel.cfc
@@ -59,7 +59,10 @@ component {
 	/**
 	* I get a model.
 	*/
-	public struct function get( required numeric id ) {
+	public struct function get(
+		required numeric id,
+		string withLock
+		) {
 
 		var results = getByFilter( argumentCollection = arguments );
 
@@ -82,7 +85,8 @@ component {
 		numeric poemID,
 		numeric shareID,
 		string ipAddress,
-		string withSort
+		string withSort,
+		string withLock
 		) {
 
 		return gateway.getByFilter( argumentCollection = arguments );

--- a/cfml/app/core/lib/model/session/PresenceGateway.cfc
+++ b/cfml/app/core/lib/model/session/PresenceGateway.cfc
@@ -54,6 +54,7 @@
 	<cffunction name="getByFilter" returnType="array">
 
 		<cfargument name="sessionID" type="numeric" required="false" />
+		<cfargument name="withLock" type="string" required="false" default="" />
 
 		<cfset assertIndexPrefix( arguments ) />
 
@@ -71,6 +72,15 @@
 				AND
 					sessionID = <cfqueryparam value="#sessionID#" cfsqltype="bigint" />
 			</cfif>
+
+			<cfswitch expression="#withLock#">
+				<cfcase value="readonly">
+					FOR SHARE
+				</cfcase>
+				<cfcase value="exclusive">
+					FOR UPDATE
+				</cfcase>
+			</cfswitch>
 		</cfquery>
 
 		<cfreturn results />

--- a/cfml/app/core/lib/model/session/PresenceModel.cfc
+++ b/cfml/app/core/lib/model/session/PresenceModel.cfc
@@ -50,7 +50,10 @@ component {
 	/**
 	* I get a model.
 	*/
-	public struct function get( required numeric sessionID ) {
+	public struct function get(
+		required numeric sessionID,
+		string withLock
+		) {
 
 		var results = getByFilter( argumentCollection = arguments );
 
@@ -68,7 +71,10 @@ component {
 	/**
 	* I get the model that match the given filters.
 	*/
-	public array function getByFilter( numeric sessionID ) {
+	public array function getByFilter(
+		numeric sessionID,
+		string withLock
+		) {
 
 		return gateway.getByFilter( argumentCollection = arguments );
 

--- a/cfml/app/core/lib/model/session/SessionGateway.cfc
+++ b/cfml/app/core/lib/model/session/SessionGateway.cfc
@@ -79,6 +79,7 @@
 		<cfargument name="userID" type="numeric" required="false" />
 		<cfargument name="token" type="string" required="false" />
 		<cfargument name="withSort" type="string" required="false" default="id" />
+		<cfargument name="withLock" type="string" required="false" default="" />
 
 		<cfset assertIndexPrefix( arguments ) />
 
@@ -119,6 +120,15 @@
 						id ASC
 					</cfdefaultcase>
 				</cfswitch>
+
+			<cfswitch expression="#withLock#">
+				<cfcase value="readonly">
+					FOR SHARE
+				</cfcase>
+				<cfcase value="exclusive">
+					FOR UPDATE
+				</cfcase>
+			</cfswitch>
 		</cfquery>
 
 		<cfreturn decodeColumns( results ) />

--- a/cfml/app/core/lib/model/session/SessionModel.cfc
+++ b/cfml/app/core/lib/model/session/SessionModel.cfc
@@ -62,7 +62,10 @@ component {
 	/**
 	* I get a model.
 	*/
-	public struct function get( required numeric id ) {
+	public struct function get(
+		required numeric id,
+		string withLock
+		) {
 
 		var results = getByFilter( argumentCollection = arguments );
 
@@ -86,7 +89,8 @@ component {
 		numeric id,
 		string token,
 		numeric userID,
-		string withSort
+		string withSort,
+		string withLock
 		) {
 
 		return gateway.getByFilter( argumentCollection = arguments );

--- a/cfml/app/core/lib/model/system/task/TaskGateway.cfc
+++ b/cfml/app/core/lib/model/system/task/TaskGateway.cfc
@@ -19,6 +19,7 @@
 		<cfargument name="id" type="string" required="false" />
 		<cfargument name="overdueAt" type="date" required="false" />
 		<cfargument name="withSort" type="string" required="false" default="id" />
+		<cfargument name="withLock" type="string" required="false" default="" />
 
 		<cfquery name="local.results" result="local.metaResults" returnType="array">
 			SELECT
@@ -51,6 +52,15 @@
 						id ASC
 					</cfdefaultcase>
 				</cfswitch>
+
+			<cfswitch expression="#withLock#">
+				<cfcase value="readonly">
+					FOR SHARE
+				</cfcase>
+				<cfcase value="exclusive">
+					FOR UPDATE
+				</cfcase>
+			</cfswitch>
 		</cfquery>
 
 		<cfreturn decodeColumns( results ) />

--- a/cfml/app/core/lib/model/system/task/TaskModel.cfc
+++ b/cfml/app/core/lib/model/system/task/TaskModel.cfc
@@ -14,7 +14,10 @@ component {
 	/**
 	* I get a model.
 	*/
-	public struct function get( required string id ) {
+	public struct function get(
+		required string id,
+		string withLock
+		) {
 
 		var results = getByFilter( argumentCollection = arguments );
 
@@ -35,7 +38,8 @@ component {
 	public array function getByFilter(
 		string id,
 		date overdueAt,
-		string withSort
+		string withSort,
+		string withLock
 		) {
 
 		return gateway.getByFilter( argumentCollection = arguments );

--- a/cfml/app/core/lib/model/user/AccountGateway.cfc
+++ b/cfml/app/core/lib/model/user/AccountGateway.cfc
@@ -52,6 +52,7 @@
 	<cffunction name="getByFilter" returnType="array">
 
 		<cfargument name="userID" type="numeric" required="false" />
+		<cfargument name="withLock" type="string" required="false" default="" />
 
 		<cfset assertIndexPrefix( arguments ) />
 
@@ -68,6 +69,15 @@
 				AND
 					userID = <cfqueryparam value="#userID#" cfsqltype="bigint" />
 			</cfif>
+
+			<cfswitch expression="#withLock#">
+				<cfcase value="readonly">
+					FOR SHARE
+				</cfcase>
+				<cfcase value="exclusive">
+					FOR UPDATE
+				</cfcase>
+			</cfswitch>
 		</cfquery>
 
 		<cfreturn results />

--- a/cfml/app/core/lib/model/user/AccountModel.cfc
+++ b/cfml/app/core/lib/model/user/AccountModel.cfc
@@ -48,7 +48,10 @@ component {
 	/**
 	* I get a model.
 	*/
-	public struct function get( required numeric userID ) {
+	public struct function get(
+		required numeric userID,
+		string withLock
+		) {
 
 		var results = getByFilter( argumentCollection = arguments );
 
@@ -66,7 +69,10 @@ component {
 	/**
 	* I get the model that match the given filters.
 	*/
-	public array function getByFilter( numeric userID ) {
+	public array function getByFilter(
+		numeric userID,
+		string withLock
+		) {
 
 		return gateway.getByFilter( argumentCollection = arguments );
 

--- a/cfml/app/core/lib/model/user/TimezoneGateway.cfc
+++ b/cfml/app/core/lib/model/user/TimezoneGateway.cfc
@@ -52,6 +52,7 @@
 	<cffunction name="getByFilter" returnType="array">
 
 		<cfargument name="userID" type="numeric" required="false" />
+		<cfargument name="withLock" type="string" required="false" default="" />
 
 		<cfset assertIndexPrefix( arguments ) />
 
@@ -68,6 +69,15 @@
 				AND
 					userID = <cfqueryparam value="#userID#" cfsqltype="bigint" />
 			</cfif>
+
+			<cfswitch expression="#withLock#">
+				<cfcase value="readonly">
+					FOR SHARE
+				</cfcase>
+				<cfcase value="exclusive">
+					FOR UPDATE
+				</cfcase>
+			</cfswitch>
 		</cfquery>
 
 		<cfreturn results />

--- a/cfml/app/core/lib/model/user/TimezoneModel.cfc
+++ b/cfml/app/core/lib/model/user/TimezoneModel.cfc
@@ -50,7 +50,10 @@ component {
 	/**
 	* I get a model.
 	*/
-	public struct function get( required numeric userID ) {
+	public struct function get(
+		required numeric userID,
+		string withLock
+		) {
 
 		var results = getByFilter( argumentCollection = arguments );
 
@@ -68,7 +71,10 @@ component {
 	/**
 	* I get the model that match the given filters.
 	*/
-	public array function getByFilter( numeric userID ) {
+	public array function getByFilter(
+		numeric userID,
+		string withLock
+		) {
 
 		return gateway.getByFilter( argumentCollection = arguments );
 
@@ -88,9 +94,7 @@ component {
 	/**
 	* I maybe get the first model that match the given filters.
 	*/
-	public struct function maybeGetByFilter(
-		numeric userID
-		) {
+	public struct function maybeGetByFilter( numeric userID ) {
 
 		return maybeArrayFirst( getByFilter( argumentCollection = arguments ) );
 

--- a/cfml/app/core/lib/model/user/UserGateway.cfc
+++ b/cfml/app/core/lib/model/user/UserGateway.cfc
@@ -67,6 +67,7 @@
 		<cfargument name="id" type="numeric" required="false" />
 		<cfargument name="email" type="string" required="false" />
 		<cfargument name="withSort" type="string" required="false" default="id" />
+		<cfargument name="withLock" type="string" required="false" default="" />
 
 		<cfset assertIndexPrefix( arguments ) />
 
@@ -97,6 +98,15 @@
 						id ASC
 					</cfdefaultcase>
 				</cfswitch>
+
+			<cfswitch expression="#withLock#">
+				<cfcase value="readonly">
+					FOR SHARE
+				</cfcase>
+				<cfcase value="exclusive">
+					FOR UPDATE
+				</cfcase>
+			</cfswitch>
 		</cfquery>
 
 		<cfreturn results />

--- a/cfml/app/core/lib/model/user/UserModel.cfc
+++ b/cfml/app/core/lib/model/user/UserModel.cfc
@@ -59,7 +59,10 @@ component {
 	/**
 	* I get a model.
 	*/
-	public struct function get( required numeric id ) {
+	public struct function get(
+		required numeric id,
+		string withLock
+		) {
 
 		var results = getByFilter( argumentCollection = arguments );
 
@@ -80,7 +83,8 @@ component {
 	public array function getByFilter(
 		numeric id,
 		string email,
-		string withSort
+		string withSort,
+		string withLock
 		) {
 
 		return gateway.getByFilter( argumentCollection = arguments );

--- a/cfml/app/core/lib/service/poem/PoemService.cfc
+++ b/cfml/app/core/lib/service/poem/PoemService.cfc
@@ -142,35 +142,45 @@ component {
 	private void function saveRevision( required numeric poemID ) {
 
 		var windowInSeconds = 120;
-		var poem = poemModel.get( poemID );
-		var maybeLastRevision = revisionModel.maybeGetMostRecentByPoemID( poemID );
 
-		var shouldCreateNewRevision = (
-			! maybeLastRevision.exists ||
-			( dateDiff( "s", maybeLastRevision.value.updatedAt, poem.updatedAt ) >= windowInSeconds )
-		);
+		// This transaction uses an exclusive lock on the poem model in order to enforce
+		// serialized access to the poem-level revisions.
+		transaction {
 
-		// If there's no previous revision, or the window has closed, create a new one.
-		if ( shouldCreateNewRevision ) {
-
-			revisionModel.create(
-				poemID = poemID,
-				name = poem.name,
-				content = poem.content,
-				createdAt = poem.updatedAt
+			var poem = poemModel.get(
+				id = poemID,
+				withLock = "exclusive"
 			);
 
-		// Otherwise, update the existing revision within the window.
-		} else {
+			var cutoffAt = poem.updatedAt.add( "s", -windowInSeconds );
+			var maybeLastRevision = revisionModel.maybeGetMostRecentByPoemID( poemID );
 
-			revisionModel.update(
-				id = maybeLastRevision.value.id,
-				name = poem.name,
-				content = poem.content,
-				updatedAt = poem.updatedAt
-			);
+			// If there's no previous revision, or the window has closed, create a new one.
+			if (
+				! maybeLastRevision.exists ||
+				( maybeLastRevision.value.updatedAt <= cutoffAt )
+				) {
 
-		}
+				revisionModel.create(
+					poemID = poemID,
+					name = poem.name,
+					content = poem.content,
+					createdAt = poem.updatedAt
+				);
+
+			// Otherwise, update the existing revision within the window.
+			} else {
+
+				revisionModel.update(
+					id = maybeLastRevision.value.id,
+					name = poem.name,
+					content = poem.content,
+					updatedAt = poem.updatedAt
+				);
+
+			}
+
+		} // End: transaction and row-locks.
 
 	}
 

--- a/cfml/app/core/lib/service/poem/RevisionService.cfc
+++ b/cfml/app/core/lib/service/poem/RevisionService.cfc
@@ -56,46 +56,55 @@ component {
 
 		var context = revisionAccess.getContext( authContext, revisionID, "canMakeCurrent" );
 		var revision = context.revision;
-		var poem = context.poem;
 
-		// Before overwriting the poem, snapshot the current live state so the user can
-		// revert back to it. Skip this if the most recent revision already matches the
-		// live poem (no point creating a duplicate).
-		var maybeLastRevision = revisionModel.maybeGetMostRecentByPoemID( poem.id );
+		// This transaction uses an exclusive lock on the poem model in order to enforce
+		// serialized access to the poem-level revisions (which is why we're re-fetching
+		// the poem even though we could get it directly from the context).
+		transaction {
 
-		var isLastRevisionStale = (
-			! maybeLastRevision.exists ||
-			! isRevisionStale( maybeLastRevision.value, poem )
-		);
-
-		if ( isLastRevisionStale ) {
-
-			revisionModel.create(
-				poemID = poem.id,
-				name = poem.name,
-				content = poem.content,
-				createdAt = poem.updatedAt
+			var poem = poemModel.get(
+				id = context.poem.id,
+				withLock = "exclusive"
 			);
 
-		}
+			// Before overwriting the poem, snapshot the current live state so the user
+			// can revert back to it. Skip this if the most recent revision already
+			// matches the live poem (no point creating a duplicate).
+			var maybeLastRevision = revisionModel.maybeGetMostRecentByPoemID( poem.id );
 
-		// Update the poem with the revision's content.
-		poemModel.update(
-			id = poem.id,
-			name = revision.name,
-			content = revision.content,
-			updatedAt = utcNow()
-		);
+			if (
+				! maybeLastRevision.exists ||
+				isRevisionStale( maybeLastRevision.value, poem )
+				) {
 
-		// Create a new revision to snapshot the restored state.
-		var restoredPoem = poemModel.get( poem.id );
+				revisionModel.create(
+					poemID = poem.id,
+					name = poem.name,
+					content = poem.content,
+					createdAt = poem.updatedAt
+				);
 
-		revisionModel.create(
-			poemID = restoredPoem.id,
-			name = restoredPoem.name,
-			content = restoredPoem.content,
-			createdAt = restoredPoem.updatedAt
-		);
+			}
+
+			// Update the poem with the revision's content.
+			poemModel.update(
+				id = poem.id,
+				name = revision.name,
+				content = revision.content,
+				updatedAt = utcNow()
+			);
+
+			// Create a new revision to snapshot the restored state.
+			var restoredPoem = poemModel.get( poem.id );
+
+			revisionModel.create(
+				poemID = restoredPoem.id,
+				name = restoredPoem.name,
+				content = restoredPoem.content,
+				createdAt = restoredPoem.updatedAt
+			);
+
+		} // End: transaction and row-locks.
 
 	}
 

--- a/cfml/app/core/lib/service/poem/share/ShareService.cfc
+++ b/cfml/app/core/lib/service/poem/share/ShareService.cfc
@@ -2,7 +2,6 @@ component {
 
 	// Define properties for dependency-injection.
 	property name="DEFAULT_SHARE_NAME" ioc:skip;
-	property name="poemModel" ioc:type="core.lib.model.poem.PoemModel";
 	property name="requestMetadata" ioc:type="core.lib.web.RequestMetadata";
 	property name="secureRandom" ioc:type="core.lib.util.SecureRandom";
 	property name="shareAccess" ioc:type="core.lib.service.poem.share.ShareAccess";
@@ -170,8 +169,6 @@ component {
 	*/
 	public void function logShareViewing( required numeric id ) {
 
-		var share = shareModel.get( id );
-		var poem = poemModel.get( share.poemID );
 		var ipAddress = requestMetadata.getIpAddress();
 		// Let's trim the city/region since it doesn't much matter if they get truncated
 		// in the database. I'd rather them get truncated than have a user-provided value
@@ -181,27 +178,38 @@ component {
 		var ipCountry = requestMetadata.getIpCountry();
 		var createdAt = utcNow();
 
-		viewingModel.create(
-			poemID = poem.id,
-			shareID = share.id,
-			ipAddress = ipAddress,
-			ipCity = ipCity,
-			ipRegion = ipRegion,
-			ipCountry = ipCountry,
-			createdAt = createdAt
-		);
+		// This transaction uses an exclusive lock on the share model in order to enforce
+		// serialized access to the share-level view-count aggregate.
+		transaction {
 
-		// Recalculate the viewing aggregate.
-		var viewingCount = viewingModel.getCountByFilter(
-			poemID = poem.id,
-			shareID = share.id
-		);
+			var share = shareModel.get(
+				id = id,
+				withLock = "exclusive"
+			);
 
-		shareModel.update(
-			id = share.id,
-			viewingCount = viewingCount,
-			lastViewingAt = createdAt
-		);
+			viewingModel.create(
+				poemID = share.poemID,
+				shareID = share.id,
+				ipAddress = ipAddress,
+				ipCity = ipCity,
+				ipRegion = ipRegion,
+				ipCountry = ipCountry,
+				createdAt = createdAt
+			);
+
+			// Recalculate the viewing aggregate.
+			var viewingCount = viewingModel.getCountByFilter(
+				poemID = share.poemID,
+				shareID = share.id
+			);
+
+			shareModel.update(
+				id = share.id,
+				viewingCount = viewingCount,
+				lastViewingAt = createdAt
+			);
+
+		} // End: transaction and row-locks.
 
 	}
 

--- a/cfml/app/spec/suite/RevisionServiceTest.cfc
+++ b/cfml/app/spec/suite/RevisionServiceTest.cfc
@@ -110,9 +110,57 @@ component extends="spec.BaseTest" {
 		assertEqual( poem.name, oldName );
 		assertEqual( poem.content, oldContent );
 
-		// Verify new revisions were created (snapshot of live state + snapshot of restored state).
+		// Verify new revisions were created (snapshot of live state + snapshot of restored
+		// state = 2 new revisions).
 		var revisionsAfter = revisionModel.getByFilter( poemID = poemID );
-		assertTrue( revisionsAfter.len() > revisionCountBefore, "Expected new revisions to be created during makeCurrent." );
+		assertEqual( revisionsAfter.len(), ( revisionCountBefore + 2 ), "Expected exactly 2 new revisions (live snapshot + restored snapshot)." );
+
+	}
+
+
+	/**
+	* I test that makeCurrent skips the live-state snapshot when the most recent revision
+	* already matches the live poem content.
+	*/
+	public void function testMakeCurrentSkipsRedundantSnapshot() {
+
+		var poemID = poemService.create(
+			authContext = variables.authContext,
+			userID = variables.authContext.user.id,
+			collectionID = 0,
+			name = "Live #createUUID()#",
+			content = "Live content."
+		);
+
+		// The create call produced a revision that matches the live poem. Now create
+		// a second revision with different content to restore from.
+		var oldRevisionID = revisionModel.create(
+			poemID = poemID,
+			name = "Old #createUUID()#",
+			content = "Old content.",
+			createdAt = utcNow()
+		);
+
+		// Restore the old revision — this changes the poem away from the latest revision.
+		revisionService.makeCurrent(
+			authContext = variables.authContext,
+			revisionID = oldRevisionID
+		);
+
+		// Now the most recent revision (created by makeCurrent above) matches the live
+		// poem. Restoring the old revision again should skip the live-state snapshot
+		// because it would be a duplicate of the most recent revision.
+		var revisionCountBefore = revisionModel.getByFilter( poemID = poemID ).len();
+
+		revisionService.makeCurrent(
+			authContext = variables.authContext,
+			revisionID = oldRevisionID
+		);
+
+		// Only 1 new revision (the restored snapshot), not 2 — the live-state snapshot
+		// was correctly skipped because the most recent revision already matched.
+		var revisionsAfter = revisionModel.getByFilter( poemID = poemID );
+		assertEqual( revisionsAfter.len(), ( revisionCountBefore + 1 ), "Expected exactly 1 new revision (no redundant live snapshot)." );
 
 	}
 


### PR DESCRIPTION
I recently learned about the MySQL notion of row-level locking using `SELECT ... FOR UPDATE` and `SELECT ... FOR SHARE`. I'm roughly mapping these onto ColdFusion's notations of `exclusive` and `readonly` locks, respectively. I'm still not completely comfortable with when and how to use them; but I'm laying down the foundation for the mechanics. This commit adds a `withLock` argument to the low-level `get*` gateway methods. Then, applies some "aggregate root" style locking to the revision and share workflows.